### PR TITLE
Use system compiler linux

### DIFF
--- a/pkg/conda/fastfilters/build.sh
+++ b/pkg/conda/fastfilters/build.sh
@@ -7,6 +7,7 @@ if [ $(uname) == Darwin ]; then
 else
     CC=gcc
     CXX=g++
+    CXXFLAGS="-D_GLIBCXX_USE_CXX11_ABI=0 ${CXXFLAGS}"
 fi
 
 mkdir build_conda

--- a/pkg/conda/fastfilters/build.sh
+++ b/pkg/conda/fastfilters/build.sh
@@ -7,12 +7,18 @@ if [ $(uname) == Darwin ]; then
 else
     CC=gcc
     CXX=g++
-    CXXFLAGS="-D_GLIBCXX_USE_CXX11_ABI=0 ${CXXFLAGS}"
+    # enable compilation without CXX abi to stay compatible with gcc < 5 built packages
+    if [[ ${DO_NOT_BUILD_WITH_CXX11_ABI} == '1' ]]; then
+        CXXFLAGS="-D_GLIBCXX_USE_CXX11_ABI=0 ${CXXFLAGS}"
+    fi
 fi
 
 mkdir build_conda
 cd build_conda
-cmake -DCMAKE_INSTALL_PREFIX=${PREFIX} ..
+cmake \
+    -DCMAKE_INSTALL_PREFIX=${PREFIX} \
+    -DCMAKE_CXX_FLAGS="${CXXFLAGS}" \
+    ..
 make -j${CPU_COUNT}
 #make fastfilters_py_test
 make install

--- a/pkg/conda/fastfilters/meta.yaml
+++ b/pkg/conda/fastfilters/meta.yaml
@@ -15,7 +15,7 @@ source:
 
 
 build:
-  number: 0
+  number: 1
   string: py{{CONDA_PY}}_{{PKG_BUILDNUM}}_g{{GIT_FULL_HASH[:7]}}
   script_env:
     # Control building with CXX11 abi

--- a/pkg/conda/fastfilters/meta.yaml
+++ b/pkg/conda/fastfilters/meta.yaml
@@ -17,6 +17,9 @@ source:
 build:
   number: 0
   string: py{{CONDA_PY}}_{{PKG_BUILDNUM}}_g{{GIT_FULL_HASH[:7]}}
+  script_env:
+    # Control building with CXX11 abi
+    - DO_NOT_BUILD_WITH_CXX11_ABI  # [linux]
 
 requirements:
   build:

--- a/pkg/conda/fastfilters/meta.yaml
+++ b/pkg/conda/fastfilters/meta.yaml
@@ -23,19 +23,19 @@ requirements:
     - cmake
     - python 2.7*|3.4*|3.5*|3.6*
     - python {{PY_VER}}*
-    - numpy
+    - numpy {{NPY_VER}}*
     - nose
     - vigra
 
   run:
     - python {{PY_VER}}*
-    - numpy
+    - numpy {{NPY_VER}}*
 
 test:
   requires:
     - vigra >=1.11.0
     - nose
-    - numpy
+    - numpy {{NPY_VER}}*
 
   source_files:
     - tests


### PR DESCRIPTION
This is related to allowing dependencies to be built with newer gcc than the one available through conda (4.8.5 atm), in particular, recent nifty changes forced us to use a newer compiler.

See some more background on this in https://github.com/ilastik/ilastik-publish-packages/issues/2

In order to use the system compilers this PR removes

* references to `gcc`, `libgcc` in the respective `meta.yaml` files
* points to the correct compiler in `build.sh`
* introduces an environment variable `DO_NOT_BUILD_WITH_CXX11_ABI` that is used in the build process to enable building with `-D_GLIBCXX_USE_CXX11_ABI=0` to enable compatibility with the "old" gcc stdlib abi.