### PR TITLE
avoid errors due to 'UnknownAxisType'

### DIFF
--- a/src/python/__init__.py
+++ b/src/python/__init__.py
@@ -28,7 +28,7 @@ def __p_fix_array(func):
 			if res.shape == squeezed.shape:
 				res = vigra.taggedView( res, squeezed.axistags )
 			else:
-				res = vigra.taggedView( res, list(squeezed.axistags) + [vigra.AxisInfo('c')] )
+				res = vigra.taggedView( res, list(squeezed.axistags) + [vigra.AxisInfo.c] )
 			return res.withAxes(array.axistags)
 		else:
 			assert not any( np.array(array.shape) == 1 ), \


### PR DESCRIPTION
when adding squeezed out channel axis, create an AxisInfo object called 'c' which has the channel typeFlag (by using the Axisinfo.c factory) and do not create an AxisInfo object called 'c' with the default typeFlag, which is UnknownAxisType